### PR TITLE
Make `ignore_seek_speed` default to false.

### DIFF
--- a/addons/FMOD/editor/editor_addon.gd
+++ b/addons/FMOD/editor/editor_addon.gd
@@ -16,8 +16,6 @@ var banks_loaded_timer: Timer
 
 
 func _enter_tree():
-	FMODStudioEditorModule.init()
-
 	# Create all icons
 	create_icons()
 
@@ -26,15 +24,6 @@ func _enter_tree():
 	# Set up the icons for the custom nodes
 	# note(alex): This is very slow and results in a slower editor start
 	setup_custom_nodes_icon()
-
-	# note(alex): When we start loading the editor banks, we setup a timer so we can poll the loading
-	# state of the banks. Once the banks are loaded, the banks_loaded signal will be called and the
-	# timer will be freed.
-	if !FMODStudioEditorModule.is_connected("banks_loading", Callable(self, "on_banks_loading")):
-		FMODStudioEditorModule.connect("banks_loading", Callable(self, "on_banks_loading"))
-
-	# Load all banks
-	FMODStudioEditorModule.load_all_banks()
 
 	# Add the inspector browser plugin to Godot. Until godot-cpp#886 is fixed
 	# we need to implement this in GDScript
@@ -53,6 +42,7 @@ func _enter_tree():
 	project_preview_browser.set_editor_scale(editor_scale)
 	project_preview_browser.initialize()
 	add_control_to_container(EditorPlugin.CONTAINER_TOOLBAR, project_preview_button)
+	
 	if project_preview_button.get_child_count() == 0:
 		project_preview_button.add_child(project_preview_browser)
 		project_preview_browser.set_visible(false)
@@ -69,7 +59,6 @@ func _exit_tree():
 	remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, project_preview_button)
 	remove_inspector_plugin(inspector_browser)
 	remove_node_3d_gizmo_plugin(studio_event_emitter_3d_gizmo_plugin)
-	FMODStudioEditorModule.shutdown()
 
 
 func create_icons():
@@ -120,15 +109,3 @@ func setup_custom_nodes_icon():
 		theme.set_icon(&"StudioListener3D", &"EditorIcons", fmod_icon)
 		theme.set_icon(&"StudioListener2D", &"EditorIcons", fmod_icon)
 		get_editor_interface().get_base_control().set_theme(theme)
-
-
-func on_banks_loading():
-	print("[FMOD] Loading Editor Banks")
-	banks_loaded_timer = Timer.new()
-	add_child(banks_loaded_timer)
-	banks_loaded_timer.set_wait_time(1)
-	banks_loaded_timer.set_one_shot(false)
-	var poll_func = Callable(FMODStudioEditorModule, "poll_banks_loading_state")
-	poll_func = poll_func.bind(banks_loaded_timer)
-	banks_loaded_timer.connect("timeout", poll_func)
-	banks_loaded_timer.start()

--- a/addons/FMOD/native/src/api/studio_api.cpp
+++ b/addons/FMOD/native/src/api/studio_api.cpp
@@ -313,7 +313,7 @@ Dictionary StudioSystem::get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PA
 }
 
 bool StudioSystem::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-		bool ignore_seek_speed) const
+		bool ignore_seek_speed = false) const
 {
 	FMOD_STUDIO_PARAMETER_ID id{};
 	parameter_id->get_parameter_id(id);
@@ -322,7 +322,7 @@ bool StudioSystem::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETE
 }
 
 bool StudioSystem::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id,
-		const String& label, bool ignore_seek_speed) const
+		const String& label, bool ignore_seek_speed = false) const
 {
 	FMOD_STUDIO_PARAMETER_ID id{};
 	parameter_id->get_parameter_id(id);
@@ -331,7 +331,7 @@ bool StudioSystem::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUD
 }
 
 bool StudioSystem::set_parameters_by_ids(const Array& parameter_ids, const Array& values, int count,
-		bool ignore_seek_speed) const
+		bool ignore_seek_speed = false) const
 {
 	std::unique_ptr<FMOD_STUDIO_PARAMETER_ID[]> ids = std::make_unique<FMOD_STUDIO_PARAMETER_ID[]>(count);
 	std::unique_ptr<float[]> parameter_values = std::make_unique<float[]>(count);
@@ -364,13 +364,13 @@ Dictionary StudioSystem::get_parameter_by_name(const String& name) const
 	return result;
 }
 
-bool StudioSystem::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const
+bool StudioSystem::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const
 {
 	return ERROR_CHECK(studio_system->setParameterByName(name.utf8().get_data(), value, ignore_seek_speed));
 }
 
 bool StudioSystem::set_parameter_by_name_with_label(const String& name, const String& label,
-		bool ignore_seek_speed) const
+		bool ignore_seek_speed = false) const
 {
 	return ERROR_CHECK(
 			studio_system->setParameterByNameWithLabel(name.utf8().get_data(), label.utf8().get_data(), ignore_seek_speed));
@@ -1541,7 +1541,7 @@ Dictionary EventInstance::get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_P
 }
 
 bool EventInstance::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-		bool ignore_seek_speed) const
+		bool ignore_seek_speed = false) const
 {
 	FMOD_STUDIO_PARAMETER_ID id;
 	parameter_id->get_parameter_id(id);
@@ -1550,7 +1550,7 @@ bool EventInstance::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMET
 }
 
 bool EventInstance::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id,
-		const String& label, bool ignore_seek_speed)
+		const String& label, bool ignore_seek_speed = false)
 {
 	FMOD_STUDIO_PARAMETER_ID id;
 	parameter_id->get_parameter_id(id);
@@ -1558,7 +1558,7 @@ bool EventInstance::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STU
 	return ERROR_CHECK(event_instance->setParameterByIDWithLabel(id, label.utf8().get_data(), ignore_seek_speed));
 }
 
-bool EventInstance::set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed) const
+bool EventInstance::set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed = false) const
 {
 	std::unique_ptr<FMOD_STUDIO_PARAMETER_ID[]> parameter_ids = std::make_unique<FMOD_STUDIO_PARAMETER_ID[]>(count);
 	std::unique_ptr<float[]> parameter_values = std::make_unique<float[]>(count);
@@ -1594,12 +1594,12 @@ Dictionary EventInstance::get_parameter_by_name(const String& name) const
 	return result;
 }
 
-bool EventInstance::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const
+bool EventInstance::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const
 {
 	return ERROR_CHECK(event_instance->setParameterByName(name.utf8().get_data(), value, ignore_seek_speed));
 }
 
-bool EventInstance::set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed)
+bool EventInstance::set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed = false)
 {
 	return ERROR_CHECK(event_instance->setParameterByNameWithLabel(name.utf8().get_data(), label.utf8().get_data(),
 			ignore_seek_speed));

--- a/addons/FMOD/native/src/api/studio_api.cpp
+++ b/addons/FMOD/native/src/api/studio_api.cpp
@@ -27,16 +27,16 @@ void StudioSystem::_bind_methods()
 			&StudioSystem::get_parameter_label_by_id);
 	ClassDB::bind_method(D_METHOD("get_parameter_by_id", "parameter_id"), &StudioSystem::get_parameter_by_id);
 	ClassDB::bind_method(D_METHOD("set_parameter_by_id", "parameter_id", "value", "ignore_seek_speed"),
-			&StudioSystem::set_parameter_by_id);
+			&StudioSystem::set_parameter_by_id, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_parameter_by_id_with_label", "parameter_id", "label", "ignore_seek_speed"),
-			&StudioSystem::set_parameter_by_id_with_label);
+			&StudioSystem::set_parameter_by_id_with_label, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_parameters_by_ids", "parameter_ids", "values", "count", "ignore_seek_speed"),
-			&StudioSystem::set_parameters_by_ids);
+			&StudioSystem::set_parameters_by_ids, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_parameter_by_name", "name"), &StudioSystem::get_parameter_by_name);
 	ClassDB::bind_method(D_METHOD("set_parameter_by_name", "name", "value", "ignore_seek_speed"),
-			&StudioSystem::set_parameter_by_name);
+			&StudioSystem::set_parameter_by_name, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_parameter_by_name_with_label", "name", "label", "ignore_seek_speed"),
-			&StudioSystem::set_parameter_by_name_with_label);
+			&StudioSystem::set_parameter_by_name_with_label, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("lookup_id", "path"), &StudioSystem::lookup_id);
 	ClassDB::bind_method(D_METHOD("lookup_path", "guid"), &StudioSystem::lookup_path);
 	ClassDB::bind_method(D_METHOD("get_num_listeners"), &StudioSystem::get_num_listeners);
@@ -313,7 +313,7 @@ Dictionary StudioSystem::get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PA
 }
 
 bool StudioSystem::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-		bool ignore_seek_speed = false) const
+		bool ignore_seek_speed) const
 {
 	FMOD_STUDIO_PARAMETER_ID id{};
 	parameter_id->get_parameter_id(id);
@@ -322,7 +322,7 @@ bool StudioSystem::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETE
 }
 
 bool StudioSystem::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id,
-		const String& label, bool ignore_seek_speed = false) const
+		const String& label, bool ignore_seek_speed) const
 {
 	FMOD_STUDIO_PARAMETER_ID id{};
 	parameter_id->get_parameter_id(id);
@@ -331,7 +331,7 @@ bool StudioSystem::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUD
 }
 
 bool StudioSystem::set_parameters_by_ids(const Array& parameter_ids, const Array& values, int count,
-		bool ignore_seek_speed = false) const
+		bool ignore_seek_speed) const
 {
 	std::unique_ptr<FMOD_STUDIO_PARAMETER_ID[]> ids = std::make_unique<FMOD_STUDIO_PARAMETER_ID[]>(count);
 	std::unique_ptr<float[]> parameter_values = std::make_unique<float[]>(count);
@@ -364,13 +364,13 @@ Dictionary StudioSystem::get_parameter_by_name(const String& name) const
 	return result;
 }
 
-bool StudioSystem::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const
+bool StudioSystem::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const
 {
 	return ERROR_CHECK(studio_system->setParameterByName(name.utf8().get_data(), value, ignore_seek_speed));
 }
 
 bool StudioSystem::set_parameter_by_name_with_label(const String& name, const String& label,
-		bool ignore_seek_speed = false) const
+		bool ignore_seek_speed) const
 {
 	return ERROR_CHECK(
 			studio_system->setParameterByNameWithLabel(name.utf8().get_data(), label.utf8().get_data(), ignore_seek_speed));
@@ -1541,7 +1541,7 @@ Dictionary EventInstance::get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_P
 }
 
 bool EventInstance::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-		bool ignore_seek_speed = false) const
+		bool ignore_seek_speed) const
 {
 	FMOD_STUDIO_PARAMETER_ID id;
 	parameter_id->get_parameter_id(id);
@@ -1550,7 +1550,7 @@ bool EventInstance::set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMET
 }
 
 bool EventInstance::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id,
-		const String& label, bool ignore_seek_speed = false)
+		const String& label, bool ignore_seek_speed)
 {
 	FMOD_STUDIO_PARAMETER_ID id;
 	parameter_id->get_parameter_id(id);
@@ -1558,7 +1558,7 @@ bool EventInstance::set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STU
 	return ERROR_CHECK(event_instance->setParameterByIDWithLabel(id, label.utf8().get_data(), ignore_seek_speed));
 }
 
-bool EventInstance::set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed = false) const
+bool EventInstance::set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed) const
 {
 	std::unique_ptr<FMOD_STUDIO_PARAMETER_ID[]> parameter_ids = std::make_unique<FMOD_STUDIO_PARAMETER_ID[]>(count);
 	std::unique_ptr<float[]> parameter_values = std::make_unique<float[]>(count);
@@ -1594,12 +1594,12 @@ Dictionary EventInstance::get_parameter_by_name(const String& name) const
 	return result;
 }
 
-bool EventInstance::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const
+bool EventInstance::set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const
 {
 	return ERROR_CHECK(event_instance->setParameterByName(name.utf8().get_data(), value, ignore_seek_speed));
 }
 
-bool EventInstance::set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed = false)
+bool EventInstance::set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed)
 {
 	return ERROR_CHECK(event_instance->setParameterByNameWithLabel(name.utf8().get_data(), label.utf8().get_data(),
 			ignore_seek_speed));

--- a/addons/FMOD/native/src/api/studio_api.h
+++ b/addons/FMOD/native/src/api/studio_api.h
@@ -51,14 +51,14 @@ public:
 
 	Dictionary get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id) const;
 	bool set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-			bool ignore_seek_speed) const;
+			bool ignore_seek_speed = false) const;
 	bool set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, const String& label,
-			bool ignore_seek_speed) const;
+			bool ignore_seek_speed = false) const;
 	bool set_parameters_by_ids(const Array& parameter_ids, const Array& values, int count,
-			bool ignore_seek_speed) const;
+			bool ignore_seek_speed = false) const;
 	Dictionary get_parameter_by_name(const String& name) const;
-	bool set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const;
-	bool set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed) const;
+	bool set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const;
+	bool set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed = false) const;
 
 	String lookup_id(const String& path) const;
 	String lookup_path(const String& guid) const;
@@ -203,14 +203,14 @@ public:
 
 	Dictionary get_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id) const;
 	bool set_parameter_by_id(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id, float value,
-			bool ignore_seek_speed) const;
+			bool ignore_seek_speed = false) const;
 	bool set_parameter_by_id_with_label(const Ref<FmodTypes::FMOD_STUDIO_PARAMETER_ID>& parameter_id,
-			const String& label, bool ignore_seek_speed);
-	bool set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed) const;
+			const String& label, bool ignore_seek_speed = false);
+	bool set_parameters_by_ids(const Array ids, const Array values, int count, bool ignore_seek_speed = false) const;
 
 	Dictionary get_parameter_by_name(const String& name) const;
-	bool set_parameter_by_name(const String& name, float value, bool ignore_seek_speed) const;
-	bool set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed);
+	bool set_parameter_by_name(const String& name, float value, bool ignore_seek_speed = false) const;
+	bool set_parameter_by_name_with_label(const String& name, const String& label, bool ignore_seek_speed = false);
 
 	bool key_off() const;
 

--- a/addons/FMOD/native/src/editor/project_browser.h
+++ b/addons/FMOD/native/src/editor/project_browser.h
@@ -195,7 +195,6 @@ private:
 	void on_play_button_pressed();
 	void on_stop_button_pressed();
 	void on_checkbox_toggled(bool button_pressed);
-	void on_banks_loaded();
 	void on_event_popup_id_pressed(int32_t id);
 	void on_bank_popup_id_pressed(int32_t id);
 

--- a/addons/FMOD/native/src/editor/studio_event_emitter_3d_gizmo_plugin.cpp
+++ b/addons/FMOD/native/src/editor/studio_event_emitter_3d_gizmo_plugin.cpp
@@ -62,21 +62,20 @@ void StudioEventEmitter3DGizmoPlugin::_redraw(const Ref<EditorNode3DGizmo>& gizm
 		return;
 	}
 
-	FMOD::Studio::EventDescription* event = event_asset->get_event_description();
+	
 
-	bool is_3d{};
-	event->is3D(&is_3d);
+	bool is_3d = event_asset->get_3d();
 
 	if (!is_3d)
 	{
 		return;
 	}
 
-	float r_max{};
+	float r_max{};	
 	float r_min{};
-	float max_distance{};
-	float min_distance{};
-	event->getMinMaxDistance(&min_distance, &max_distance);
+	float max_distance = event_asset->get_max_distance();
+	float min_distance = event_asset->get_min_distance();
+
 
 	if (max_distance > CMP_EPSILON)
 	{

--- a/addons/FMOD/native/src/fmod_studio_editor_module.cpp
+++ b/addons/FMOD/native/src/fmod_studio_editor_module.cpp
@@ -623,6 +623,12 @@ Dictionary FMODStudioEditorModule::get_project_info_from_banks()
 		String guid = bank_asset->get_guid();
 		FMOD_GUID fmod_guid{};
 		FMOD_Studio_ParseID(guid.utf8().get_data(), &fmod_guid);
+
+		if (!studio_system)
+		{
+			break;
+		}
+
 		studio_system->getBankByID(&fmod_guid, &bank);
 
 		if (!FileAccess::file_exists(resource_dirs["banks"].operator godot::String() + guid + ".tres"))
@@ -766,7 +772,11 @@ Dictionary FMODStudioEditorModule::get_project_info_from_banks()
 	}
 
 	int parameter_count = 0;
-	studio_system->getParameterDescriptionCount(&parameter_count);
+
+	if (studio_system)
+	{
+		studio_system->getParameterDescriptionCount(&parameter_count);
+	}
 
 	if (parameter_count > 0)
 	{

--- a/addons/FMOD/native/src/fmod_studio_editor_module.cpp
+++ b/addons/FMOD/native/src/fmod_studio_editor_module.cpp
@@ -505,7 +505,14 @@ void FMODStudioEditorModule::load_all_banks()
 		}
 
 		FMOD::Studio::Bank* bank = nullptr;
-		ERROR_CHECK(studio_system->loadBankFile(file_path.utf8().get_data(), FMOD_STUDIO_LOAD_BANK_NORMAL, &bank));
+		FMOD_RESULT result = studio_system->loadBankFile(file_path.utf8().get_data(), FMOD_STUDIO_LOAD_BANK_NORMAL, &bank);
+		{
+			if (result != FMOD_RESULT::FMOD_ERR_EVENT_ALREADY_LOADED)
+			{
+				ERROR_CHECK(result);
+			}
+		}
+
 		Ref<BankAsset> bank_asset = get_bank_reference(bank_files_infos[i]);
 		bank_asset->set_bank_ref(bank);
 		bank_refs.append(bank_asset);

--- a/addons/FMOD/native/src/fmod_studio_editor_module.h
+++ b/addons/FMOD/native/src/fmod_studio_editor_module.h
@@ -136,7 +136,6 @@ public:
 	void set_is_initialized(bool initialized);
 	bool get_is_initialized() const;
 
-	void poll_banks_loading_state(Timer* timer);
 	bool get_all_banks_loaded() const;
 };
 

--- a/addons/FMOD/native/src/misc/fmod_io.h
+++ b/addons/FMOD/native/src/misc/fmod_io.h
@@ -27,6 +27,8 @@ public:
 		if (FileAccess::get_open_error() != Error::OK)
 		{
 			*filesize = 0;
+			file->close();
+			memfree(file_handle);
 			return FMOD_ERR_FILE_NOTFOUND;
 		}
 
@@ -44,7 +46,9 @@ public:
 			return result;
 		}
 
-		memfree(handle);
+		FileHandle* const file_handle = static_cast<FileHandle*>(handle);
+		file_handle->file->close();
+		memfree(file_handle);
 
 		result = FMOD_OK;
 		return result;

--- a/addons/FMOD/native/src/utils/fmod_utils.h
+++ b/addons/FMOD/native/src/utils/fmod_utils.h
@@ -28,11 +28,10 @@ static bool error_check(const FMOD_RESULT result, const char* function, const ch
 {
 	if (result != FMOD_OK)
 	{
-#ifdef FMOD_DEBUG
 		String warning_message = "[WARNING]: " + String(FMOD_ErrorString(result)) + " " + function + " in " + file +
 				":" + String::num(line);
 		UtilityFunctions::push_warning(warning_message);
-#endif
+
 		return false;
 	}
 


### PR DESCRIPTION
`ignore_seek_speed` has a default value of false in the FMOD api, however this is missing in this version, creating redundant code that's inconsistent with what FMOD states.

I could not test this as I have run into issues building this repository before (straight from source), but the changes are minimal enough  that there should be no issues.