### PR TITLE
Rename the RuntimeManager more logically

### DIFF
--- a/addons/FMOD/fmod.gd
+++ b/addons/FMOD/fmod.gd
@@ -5,8 +5,8 @@ var editor_addon: EditorPlugin
 
 
 func _enter_tree():
-	if !ProjectSettings.has_setting("autoload/RuntimeManager"):
-		add_autoload_singleton("RuntimeManager", "res://addons/FMOD/runtime/runtime_manager.gd")
+	if !ProjectSettings.has_setting("autoload/FmodManager"):
+		add_autoload_singleton("FmodManager", "res://addons/FMOD/runtime/runtime_manager.gd")
 
 	# note(alex): _enter_tree is called twice here (bug?) so we check if we are already initialized
 	if !FMODStudioEditorModule.get_is_initialized():
@@ -20,4 +20,4 @@ func _exit_tree():
 	if FMODStudioEditorModule.get_is_initialized():
 		get_editor_interface().get_base_control().remove_child(editor_addon)
 		editor_addon.queue_free()
-	remove_autoload_singleton("RuntimeManager")
+	remove_autoload_singleton("FmodManager")

--- a/addons/FMOD/runtime/runtime_manager.gd
+++ b/addons/FMOD/runtime/runtime_manager.gd
@@ -30,12 +30,12 @@ func _notification(what: int) -> void:
 
 
 func path_to_guid(path: String) -> String:
-	return RuntimeManager.studio_system.lookup_id(path)
+	return FmodManager.studio_system.lookup_id(path)
 
 
 func get_event_description(event_asset: EventAsset) -> EventDescription:
 	var description: EventDescription
-	description = RuntimeManager.studio_system.get_event_by_id(event_asset.guid)
+	description = FmodManager.studio_system.get_event_by_id(event_asset.guid)
 	return description
 
 
@@ -47,7 +47,7 @@ func get_event_description_path(event_path: String) -> EventDescription:
 
 func get_event_description_id(guid: String) -> EventDescription:
 	var description: EventDescription
-	description = RuntimeManager.studio_system.get_event_by_id(guid)
+	description = FmodManager.studio_system.get_event_by_id(guid)
 	return description
 
 
@@ -124,7 +124,7 @@ func play_one_shot_id(guid: String, position = null) -> void:
 
 
 func attach_instance_to_node(instance: EventInstance, node, physicsbody = null) -> void:
-	var runtime_manager = RuntimeManager
+	var runtime_manager = FmodManager
 	var attached_instance: AttachedInstance
 	for i in runtime_manager.attached_instances.size():
 		if runtime_manager.attached_instances[i].instance == instance:
@@ -141,7 +141,7 @@ func attach_instance_to_node(instance: EventInstance, node, physicsbody = null) 
 
 
 func detach_instance_from_node(instance: EventInstance) -> void:
-	var runtime_manager = RuntimeManager
+	var runtime_manager = FmodManager
 	for i in runtime_manager.attached_instances.size():
 		if runtime_manager.attached_instances[i].instance == instance:
 			runtime_manager.attached_instances[i] = runtime_manager.attached_instances[

--- a/addons/FMOD/tests/fmod_test_framework.gd
+++ b/addons/FMOD/tests/fmod_test_framework.gd
@@ -74,7 +74,7 @@ func run_tests(tests, randomize) -> Dictionary:
 	if randomize:
 		tests.shuffle()
 	for test in tests:
-		RuntimeManager.studio_system.update()
+		FmodManager.studio_system.update()
 		if test["func"].call():
 			passed += 1
 			print_rich("[color=green]PASS: ", test["name"] + "[/color]")

--- a/addons/FMOD/tests/test_studiosystem.gd
+++ b/addons/FMOD/tests/test_studiosystem.gd
@@ -65,7 +65,7 @@ func test_get_bank() -> bool:
 
 
 func test_get_event_by_id() -> bool:
-	var guid = RuntimeManager.path_to_guid("event:/TestEvent")
+	var guid = FmodManager.path_to_guid("event:/TestEvent")
 	var result_1 = FMODStudioModule.get_studio_system().get_event_by_id(guid)
 	var result_2 = fmod_assert(result_1 is EventDescription)
 	if result_1 and result_2:
@@ -76,7 +76,7 @@ func test_get_event_by_id() -> bool:
 
 
 func test_get_bus_by_id() -> bool:
-	var guid = RuntimeManager.path_to_guid("bus:/TestBus")
+	var guid = FmodManager.path_to_guid("bus:/TestBus")
 	var result_1 = FMODStudioModule.get_studio_system().get_bus_by_id(guid)
 	var result_2 = fmod_assert(result_1 is Bus)
 	if result_1 and result_2:
@@ -87,7 +87,7 @@ func test_get_bus_by_id() -> bool:
 
 
 func test_get_vca_by_id() -> bool:
-	var guid = RuntimeManager.path_to_guid("vca:/TestVCA")
+	var guid = FmodManager.path_to_guid("vca:/TestVCA")
 	var result_1 = FMODStudioModule.get_studio_system().get_vca_by_id(guid)
 	var result_2 = fmod_assert(result_1 is VCA)
 	if result_1 and result_2:
@@ -98,7 +98,7 @@ func test_get_vca_by_id() -> bool:
 
 
 func test_get_bank_by_id() -> bool:
-	var guid = RuntimeManager.path_to_guid("bank:/Master")
+	var guid = FmodManager.path_to_guid("bank:/Master")
 	var result_1 = FMODStudioModule.get_studio_system().get_bank_by_id(guid)
 	var result_2 = fmod_assert(result_1 is Bank)
 	if result_1 and result_2:


### PR DESCRIPTION
I went through the project and renamed every reference to `RuntimeManager` as `FmodManager`, a more intuitive name for what it does.

Please note that this would be a breaking change, albeit one that could be easily solved with a simple search and replace across a project.