### PR TITLE
Streamlined FMOD Editor Initialization and Bank Loading Refactoring

### DIFF
--- a/addons/FMOD/editor/editor_addon.gd
+++ b/addons/FMOD/editor/editor_addon.gd
@@ -16,8 +16,6 @@ var banks_loaded_timer: Timer
 
 
 func _enter_tree():
-	FMODStudioEditorModule.init()
-
 	# Create all icons
 	create_icons()
 
@@ -26,15 +24,6 @@ func _enter_tree():
 	# Set up the icons for the custom nodes
 	# note(alex): This is very slow and results in a slower editor start
 	setup_custom_nodes_icon()
-
-	# note(alex): When we start loading the editor banks, we setup a timer so we can poll the loading
-	# state of the banks. Once the banks are loaded, the banks_loaded signal will be called and the
-	# timer will be freed.
-	if !FMODStudioEditorModule.is_connected("banks_loading", Callable(self, "on_banks_loading")):
-		FMODStudioEditorModule.connect("banks_loading", Callable(self, "on_banks_loading"))
-
-	# Load all banks
-	FMODStudioEditorModule.load_all_banks()
 
 	# Add the inspector browser plugin to Godot. Until godot-cpp#886 is fixed
 	# we need to implement this in GDScript
@@ -53,6 +42,7 @@ func _enter_tree():
 	project_preview_browser.set_editor_scale(editor_scale)
 	project_preview_browser.initialize()
 	add_control_to_container(EditorPlugin.CONTAINER_TOOLBAR, project_preview_button)
+	
 	if project_preview_button.get_child_count() == 0:
 		project_preview_button.add_child(project_preview_browser)
 		project_preview_browser.set_visible(false)
@@ -69,7 +59,6 @@ func _exit_tree():
 	remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, project_preview_button)
 	remove_inspector_plugin(inspector_browser)
 	remove_node_3d_gizmo_plugin(studio_event_emitter_3d_gizmo_plugin)
-	FMODStudioEditorModule.shutdown()
 
 
 func create_icons():
@@ -120,15 +109,3 @@ func setup_custom_nodes_icon():
 		theme.set_icon(&"StudioListener3D", &"EditorIcons", fmod_icon)
 		theme.set_icon(&"StudioListener2D", &"EditorIcons", fmod_icon)
 		get_editor_interface().get_base_control().set_theme(theme)
-
-
-func on_banks_loading():
-	print("[FMOD] Loading Editor Banks")
-	banks_loaded_timer = Timer.new()
-	add_child(banks_loaded_timer)
-	banks_loaded_timer.set_wait_time(1)
-	banks_loaded_timer.set_one_shot(false)
-	var poll_func = Callable(FMODStudioEditorModule, "poll_banks_loading_state")
-	poll_func = poll_func.bind(banks_loaded_timer)
-	banks_loaded_timer.connect("timeout", poll_func)
-	banks_loaded_timer.start()

--- a/addons/FMOD/native/src/editor/project_browser.h
+++ b/addons/FMOD/native/src/editor/project_browser.h
@@ -195,7 +195,6 @@ private:
 	void on_play_button_pressed();
 	void on_stop_button_pressed();
 	void on_checkbox_toggled(bool button_pressed);
-	void on_banks_loaded();
 	void on_event_popup_id_pressed(int32_t id);
 	void on_bank_popup_id_pressed(int32_t id);
 

--- a/addons/FMOD/native/src/editor/studio_event_emitter_3d_gizmo_plugin.cpp
+++ b/addons/FMOD/native/src/editor/studio_event_emitter_3d_gizmo_plugin.cpp
@@ -62,21 +62,20 @@ void StudioEventEmitter3DGizmoPlugin::_redraw(const Ref<EditorNode3DGizmo>& gizm
 		return;
 	}
 
-	FMOD::Studio::EventDescription* event = event_asset->get_event_description();
+	
 
-	bool is_3d{};
-	event->is3D(&is_3d);
+	bool is_3d = event_asset->get_3d();
 
 	if (!is_3d)
 	{
 		return;
 	}
 
-	float r_max{};
+	float r_max{};	
 	float r_min{};
-	float max_distance{};
-	float min_distance{};
-	event->getMinMaxDistance(&min_distance, &max_distance);
+	float max_distance = event_asset->get_max_distance();
+	float min_distance = event_asset->get_min_distance();
+
 
 	if (max_distance > CMP_EPSILON)
 	{

--- a/addons/FMOD/native/src/fmod_studio_editor_module.h
+++ b/addons/FMOD/native/src/fmod_studio_editor_module.h
@@ -136,7 +136,6 @@ public:
 	void set_is_initialized(bool initialized);
 	bool get_is_initialized() const;
 
-	void poll_banks_loading_state(Timer* timer);
 	bool get_all_banks_loaded() const;
 };
 

--- a/addons/FMOD/native/src/misc/fmod_io.h
+++ b/addons/FMOD/native/src/misc/fmod_io.h
@@ -27,6 +27,8 @@ public:
 		if (FileAccess::get_open_error() != Error::OK)
 		{
 			*filesize = 0;
+			file->close();
+			memfree(file_handle);
 			return FMOD_ERR_FILE_NOTFOUND;
 		}
 
@@ -44,7 +46,9 @@ public:
 			return result;
 		}
 
-		memfree(handle);
+		FileHandle* const file_handle = static_cast<FileHandle*>(handle);
+		file_handle->file->close();
+		memfree(file_handle);
 
 		result = FMOD_OK;
 		return result;


### PR DESCRIPTION
This PR introduces following changes:

- Proper file closure in the custom I/O hook has been implemented.
- The initialization of the editor studio system occurs upon the project browser's opening and concludes when closed, paralleling the behavior for editor banks. Banks will load in blocking mode.
- The Project Browser window runs in exclusive mode, necessitating active closure to prevent potential out-of-focus issues.
- Adjustments have been made to the StudioEventEmitter3D gizmo due to limitations in accessing EventDescriptions during the editor stage.