### PR TITLE
Enhance Error Checking for Release Builds

### DIFF
--- a/addons/FMOD/native/src/utils/fmod_utils.h
+++ b/addons/FMOD/native/src/utils/fmod_utils.h
@@ -28,11 +28,10 @@ static bool error_check(const FMOD_RESULT result, const char* function, const ch
 {
 	if (result != FMOD_OK)
 	{
-#ifdef FMOD_DEBUG
 		String warning_message = "[WARNING]: " + String(FMOD_ErrorString(result)) + " " + function + " in " + file +
 				":" + String::num(line);
 		UtilityFunctions::push_warning(warning_message);
-#endif
+
 		return false;
 	}
 


### PR DESCRIPTION
Previously restricted to debug builds, warning message printing has now been expanded to release builds. This change is especially pertinent as the editor inherently loads the release version of the library by default.