### PR TITLE
Remove excess DPI multiplication

### DIFF
--- a/addons/FMOD/native/src/editor/inspector_browser.cpp
+++ b/addons/FMOD/native/src/editor/inspector_browser.cpp
@@ -3,8 +3,6 @@
 
 using namespace godot;
 
-const int BASE_DPI = 96;
-
 void FMODEditorInspectorTree::_bind_methods()
 {
 	ClassDB::bind_method(D_METHOD("on_size_changed"), &FMODEditorInspectorTree::on_size_changed);
@@ -365,21 +363,7 @@ void FMODEditorInspector::initialize()
 	root_vbox->set_name("ParentVBoxContainer");
 
 	Size2 window_size = Size2(400, 680);
-	DisplayServer* display_server = DisplayServer::get_singleton();
-
-	if (display_server)
-	{
-		int32_t dpi = display_server->screen_get_dpi();
-
-		if (dpi != 72)
-		{
-			int dpi_scaling_factor = 1;
-			dpi_scaling_factor = dpi / BASE_DPI;
-			window_size *= dpi_scaling_factor;
-		}
-
-		window_size *= editor_scale;
-	}
+	window_size *= editor_scale;
 
 	root_vbox->set_size(window_size);
 	root_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/addons/FMOD/native/src/editor/project_browser.cpp
+++ b/addons/FMOD/native/src/editor/project_browser.cpp
@@ -3,7 +3,6 @@
 using namespace godot;
 
 const Size2i BASE_WINDOW_SIZE = Size2i(750, 550);
-const int BASE_DPI = 96;
 const int STANDARD_MARGIN = 10;
 
 void FMODProjectBrowserTree::_bind_methods()

--- a/addons/FMOD/native/src/editor/project_browser.cpp
+++ b/addons/FMOD/native/src/editor/project_browser.cpp
@@ -673,20 +673,7 @@ void FMODProjectBrowserWindow::initialize()
 	connect("size_changed", Callable(this, "on_size_changed"));
 
 	Size2 window_size = BASE_WINDOW_SIZE;
-	DisplayServer* display_server = DisplayServer::get_singleton();
-
-	if (display_server)
-	{
-		int32_t dpi = display_server->screen_get_dpi();
-
-		if (dpi != 72)
-		{
-			dpi_scaling_factor = dpi / BASE_DPI;
-			window_size *= dpi_scaling_factor;
-		}
-
-		window_size *= editor_scale;
-	}
+	window_size *= editor_scale;
 
 	parent_vbox_container = memnew(VBoxContainer);
 	parent_vbox_container->set_size(window_size);

--- a/addons/FMOD/native/src/editor/project_browser.h
+++ b/addons/FMOD/native/src/editor/project_browser.h
@@ -176,7 +176,6 @@ private:
 	const String github_url = "https://github.com/alessandrofama/fmod-for-godot/";
 	const String tutorials_url = "https://alessandrofama.com/tutorials/fmod/godot/";
 	const String email_url = "mailto:me@alessandrofama.com?subject=FMOD%20for%20Godot%20Integration";
-	int dpi_scaling_factor{ 1 };
 	float editor_scale{ 1.0f };
 
 	void popup_menu(PopupType type, Vector2 pos);


### PR DESCRIPTION
This removes the extra DPI calculation as the system DPI, or at least the effective DPI that the user would like to use, is already included in the editor scale 😀