### PR TITLE
FMODRuntimeManager: dont free child node

### DIFF
--- a/addons/FMOD/runtime/fmod_runtime_manager.gd
+++ b/addons/FMOD/runtime/fmod_runtime_manager.gd
@@ -24,8 +24,6 @@ func _enter_tree() -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_WM_CLOSE_REQUEST:
-		if get_child(0) && debug_scene:
-			debug_scene.free()
 		FMODStudioModule.shutdown()
 
 


### PR DESCRIPTION
nodes are freed when the parent is freed, this just causes an error print sometimes